### PR TITLE
Use built-in try/catch

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -21,7 +21,6 @@ my $build = Module::Build->new(
     'HTML::T5'             => 0,
     'HTML::Scrubber'       => 0,
     'Moose'                => 0,
-    'Try::Tiny'            => 0,
     'MooseX::Traits'       => 0,
     'namespace::autoclean' => 0,
     'MooseX::ConfigFromFile' => 0,

--- a/lib/Perlanet.pm
+++ b/lib/Perlanet.pm
@@ -1,8 +1,10 @@
 package Perlanet;
 
-use 5.10.0;
+use 5.34.0;
 use strict;
 use warnings;
+
+use feature 'try';
 
 use Moose;
 use namespace::autoclean;

--- a/lib/Perlanet.pm
+++ b/lib/Perlanet.pm
@@ -11,7 +11,6 @@ use DateTime::Duration;
 use DateTime;
 use Perlanet::Entry;
 use Perlanet::Feed;
-use Try::Tiny;
 use URI::Fetch;
 use XML::Feed;
 
@@ -238,10 +237,10 @@ sub fetch_feeds {
 
       push @valid_feeds, $feed;
     }
-    catch {
+    catch ($e) {
       warn 'Errors parsing ' . $feed->feed, "\n";
-      warn "$_\n" if defined $_;
-    };
+      warn "$e\n" if defined $e;
+    }
   }
 
   return \@valid_feeds;


### PR DESCRIPTION
Fixes #28

Update `lib/Perlanet.pm` to use built-in try/catch for exception handling.

* Remove the `use Try::Tiny` statement.
* Replace the `try` block in the `fetch_feeds` method with the built-in `try` block.
* Replace the `catch` block in the `fetch_feeds` method with the built-in `catch` block.

Update `Build.PL` to remove the `Try::Tiny` dependency.

* Remove the `Try::Tiny` dependency from the `requires` section.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/davorg-cpan/perlanet/pull/34?shareId=c37c1ee0-d691-4c37-8656-caeb1dc0e40f).